### PR TITLE
Introduce `queue.delay.*` metric

### DIFF
--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -5,10 +5,9 @@ import (
 	"flag"
 	"fmt"
 	"net/http"
+	"regexp"
 	"strings"
 	"time"
-
-	"regexp"
 
 	mp "github.com/mackerelio/go-mackerel-plugin"
 )

--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	mp "github.com/mackerelio/go-mackerel-plugin"
 )
@@ -138,6 +139,16 @@ func (p FireworqPlugin) FetchMetrics() (map[string]float64, error) {
 	}
 	m["active_nodes"] = float64(sum.ActiveNodes)
 	m["active_nodes_percentage"] = float64(sum.ActiveNodes*100) / float64(len(stats))
+
+	for q, s := range stats {
+		if s.ActiveNodes >= 1 {
+			var delay float64
+			if job, _ := p.fetchMostDelayedJob(q); job != nil {
+				delay = float64(time.Since(job.NextTry).Seconds())
+			}
+			m[fmt.Sprintf("queue.delay.%s", q)] = delay
+		}
+	}
 
 	return m, nil
 }

--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -114,6 +114,13 @@ func (p FireworqPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "queue_outstanding_jobs", Label: "Outstanding Jobs"},
 			},
 		},
+		"queue.delay": {
+			Label: p.LabelPrefix + " Delayed Time in sec",
+			Unit:  "integer",
+			Metrics: []mp.Metrics{
+				{Name: "*"},
+			},
+		},
 		"jobs": {
 			Label: p.LabelPrefix + " Jobs",
 			Unit:  "integer",

--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -8,6 +8,8 @@ import (
 	"strings"
 	"time"
 
+	"regexp"
+
 	mp "github.com/mackerelio/go-mackerel-plugin"
 )
 
@@ -146,6 +148,10 @@ func (p FireworqPlugin) FetchMetrics() (map[string]float64, error) {
 			if job, _ := p.fetchMostDelayedJob(q); job != nil {
 				delay = float64(time.Since(job.NextTry).Seconds())
 			}
+			// Escape queue name to confirm to metric name specification.
+			// See also: https://mackerel.io/ja/api-docs/entry/host-metrics#post-graphdef
+			r := regexp.MustCompile("[^-a-zA-Z0-9_]")
+			q = r.ReplaceAllString(q, "-")
 			m[fmt.Sprintf("queue.delay.%s", q)] = delay
 		}
 	}

--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -12,6 +12,12 @@ import (
 	mp "github.com/mackerelio/go-mackerel-plugin"
 )
 
+var (
+	// We need escape queue name to confirm to metric name specification.
+	// See also: https://mackerel.io/ja/api-docs/entry/host-metrics#post-graphdef
+	invalidNameReg = regexp.MustCompile("[^-a-zA-Z0-9_]")
+)
+
 // FireworqStats represents the statistics of Fireworq
 type FireworqStats struct {
 	TotalPushes     int64 `json:"total_pushes"`
@@ -143,10 +149,7 @@ func (p FireworqPlugin) FetchMetrics() (map[string]float64, error) {
 
 	for q, s := range stats {
 		if s.ActiveNodes >= 1 {
-			// Escape queue name to confirm to metric name specification.
-			// See also: https://mackerel.io/ja/api-docs/entry/host-metrics#post-graphdef
-			r := regexp.MustCompile("[^-a-zA-Z0-9_]")
-			q = r.ReplaceAllString(q, "-")
+			q = invalidNameReg.ReplaceAllString(q, "-")
 
 			if job, err := p.fetchMostDelayedJob(q); err == nil {
 				var delay float64

--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -149,8 +149,8 @@ func (p FireworqPlugin) FetchMetrics() (map[string]float64, error) {
 			r := regexp.MustCompile("[^-a-zA-Z0-9_]")
 			q = r.ReplaceAllString(q, "-")
 
-			var delay float64
 			if job, err := p.fetchMostDelayedJob(q); err == nil {
+				var delay float64
 				if job != nil {
 					delay = float64(time.Since(job.NextTry).Seconds())
 				}

--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -144,15 +144,18 @@ func (p FireworqPlugin) FetchMetrics() (map[string]float64, error) {
 
 	for q, s := range stats {
 		if s.ActiveNodes >= 1 {
-			var delay float64
-			if job, _ := p.fetchMostDelayedJob(q); job != nil {
-				delay = float64(time.Since(job.NextTry).Seconds())
-			}
 			// Escape queue name to confirm to metric name specification.
 			// See also: https://mackerel.io/ja/api-docs/entry/host-metrics#post-graphdef
 			r := regexp.MustCompile("[^-a-zA-Z0-9_]")
 			q = r.ReplaceAllString(q, "-")
-			m[fmt.Sprintf("queue.delay.%s", q)] = delay
+
+			var delay float64
+			if job, err := p.fetchMostDelayedJob(q); err == nil {
+				if job != nil {
+					delay = float64(time.Since(job.NextTry).Seconds())
+				}
+				m[fmt.Sprintf("queue.delay.%s", q)] = delay
+			}
 		}
 	}
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9955/63821802-5711d600-c989-11e9-93c9-b5a98cebf6b3.png)
(screenshot at developing)

# What
- I introduce new `queue.delay.*` metric to plot job delaying time for each queue.
- `delaying time` means duration from waiting/grabbed job's `next_try` to now in second.

# Why
- We need to monitor delaying time to alert long delaying job.