### PR TITLE
Avoid empty label for delay metric graph definition.

### DIFF
--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -192,7 +192,7 @@ func (p FireworqPlugin) GraphDefinition() map[string]mp.Graphs {
 		},
 		"queue.delay": {
 			Label: p.LabelPrefix + " Delayed Time in sec",
-			Unit:  "integer",
+			Unit:  "float",
 			Metrics: []mp.Metrics{
 				{Name: "*", Label: "%1"},
 			},

--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -194,7 +194,7 @@ func (p FireworqPlugin) GraphDefinition() map[string]mp.Graphs {
 			Label: p.LabelPrefix + " Delayed Time in sec",
 			Unit:  "integer",
 			Metrics: []mp.Metrics{
-				{Name: "*"},
+				{Name: "*", Label: "%1"},
 			},
 		},
 		"jobs": {


### PR DESCRIPTION
# What
- Set label to `%1` to avoid empty label.
- Use `float` unit.

| before | after |
|--|--|
| ![image](https://user-images.githubusercontent.com/9955/63828114-6e0ff280-c9a0-11e9-9c05-cf397b4872a7.png) | ![image](https://user-images.githubusercontent.com/9955/63828190-a44d7200-c9a0-11e9-8d1b-2eafa069482f.png) |


