### PR TITLE
Send 0 as delayed time when the node is inactive.

### DIFF
--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -148,17 +148,17 @@ func (p FireworqPlugin) FetchMetrics() (map[string]float64, error) {
 	m["active_nodes_percentage"] = float64(sum.ActiveNodes*100) / float64(len(stats))
 
 	for q, s := range stats {
-		q = invalidNameReg.ReplaceAllString(q, "-")
+		metricName := fmt.Sprintf("queue.delay.%s", invalidNameReg.ReplaceAllString(q, "-"))
 		if s.ActiveNodes >= 1 {
 			if job, err := p.fetchMostDelayedJob(q); err == nil {
 				var delay float64
 				if job != nil {
 					delay = float64(time.Since(job.NextTry).Seconds())
 				}
-				m[fmt.Sprintf("queue.delay.%s", q)] = delay
+				m[metricName] = delay
 			}
 		} else {
-			m[fmt.Sprintf("queue.delay.%s", q)] = 0
+			m[metricName] = 0
 		}
 	}
 

--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -148,9 +148,8 @@ func (p FireworqPlugin) FetchMetrics() (map[string]float64, error) {
 	m["active_nodes_percentage"] = float64(sum.ActiveNodes*100) / float64(len(stats))
 
 	for q, s := range stats {
+		q = invalidNameReg.ReplaceAllString(q, "-")
 		if s.ActiveNodes >= 1 {
-			q = invalidNameReg.ReplaceAllString(q, "-")
-
 			if job, err := p.fetchMostDelayedJob(q); err == nil {
 				var delay float64
 				if job != nil {
@@ -158,6 +157,8 @@ func (p FireworqPlugin) FetchMetrics() (map[string]float64, error) {
 				}
 				m[fmt.Sprintf("queue.delay.%s", q)] = delay
 			}
+		} else {
+			m[fmt.Sprintf("queue.delay.%s", q)] = 0
 		}
 	}
 


### PR DESCRIPTION
Bug fix for https://github.com/fireworq/mackerel-plugin-fireworq/pull/1

# Problem
- Some job is delayed and alert is fired. (active: `node 1`)
- Switch active node to `node 2`.
- Plugin send delayed metric to `node 2` only.
- Thus, `node 1` 's alert is never close.

# Solve
- Send 0 as delayed time to inactive node at all times.