### PR TITLE
Add some metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,10 @@ A [Fireworq][] custom metrics plugin for mackerel.io agent.
 ## Synopsis
 
 ```shell
-mackerel-plugin-fireworq [-scheme=<'http'|'https'>] [-host=<host>] [-port=<manage_port>] [-tempfile=<tempfile>] [-metric-key-prefix=<prefix>] [-metric-label-prefix=<label-prefix>]
+mackerel-plugin-fireworq [-scheme=<'http'|'https'>] [-host=<host>] [-port=<manage_port>] [-tempfile=<tempfile>] [-metric-key-prefix=<prefix>] [-metric-label-prefix=<label-prefix>] [-queue-stats=<comma-separated-queue-stats>]
 ```
+
+Queue stats can contain `pushes`, `pops`, `successes`, `failed`, `permanent_failed`, `completes`. The default is nothing. If you want to record all, use `-queue-stats='pushes,pops,successes,failures,permanent_failures,completes'`.
 
 ## Example of mackerel-agent.conf
 

--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -280,7 +280,7 @@ func Do() {
 	fireworq.LabelPrefix = *optLabelPrefix
 
 	rawQueueStats := strings.Split(strings.Join(strings.Fields(*optQueueStats), ""), ",")
-	stats := make([]QueueStat, 0)
+	stats := make([]QueueStat, 0, len(rawQueueStats))
 	for _, s := range rawQueueStats {
 		stats = append(stats, NewQueueStat(s))
 	}

--- a/lib/fireworq.go
+++ b/lib/fireworq.go
@@ -20,16 +20,17 @@ var (
 
 // FireworqStats represents the statistics of Fireworq
 type FireworqStats struct {
-	TotalPushes     int64 `json:"total_pushes"`
-	TotalPops       int64 `json:"total_pops"`
-	TotalSuccesses  int64 `json:"total_successes"`
-	TotalFailures   int64 `json:"total_failures"`
-	TotalCompletes  int64 `json:"total_completes"`
-	TotalElapsed    int64 `json:"total_elapsed"`
-	OutstandingJobs int64 `json:"outstanding_jobs"`
-	TotalWorkers    int64 `json:"total_workers"`
-	IdleWorkers     int64 `json:"idle_workers"`
-	ActiveNodes     int64 `json:"active_nodes"`
+	TotalPushes            int64 `json:"total_pushes"`
+	TotalPops              int64 `json:"total_pops"`
+	TotalSuccesses         int64 `json:"total_successes"`
+	TotalFailures          int64 `json:"total_failures"`
+	TotalPermanentFailures int64 `json:"total_permanent_failures"`
+	TotalCompletes         int64 `json:"total_completes"`
+	TotalElapsed           int64 `json:"total_elapsed"`
+	OutstandingJobs        int64 `json:"outstanding_jobs"`
+	TotalWorkers           int64 `json:"total_workers"`
+	IdleWorkers            int64 `json:"idle_workers"`
+	ActiveNodes            int64 `json:"active_nodes"`
 }
 
 // InspectedJob describes a job in a queue.
@@ -114,6 +115,7 @@ func (p FireworqPlugin) FetchMetrics() (map[string]float64, error) {
 		sum.TotalPops += s.TotalPops
 		sum.TotalSuccesses += s.TotalSuccesses
 		sum.TotalFailures += s.TotalFailures
+		sum.TotalPermanentFailures += s.TotalPermanentFailures
 		sum.TotalCompletes += s.TotalCompletes
 		sum.TotalElapsed += s.TotalElapsed
 		sum.OutstandingJobs += s.OutstandingJobs
@@ -137,6 +139,7 @@ func (p FireworqPlugin) FetchMetrics() (map[string]float64, error) {
 	m["jobs_events_pushed"] = float64(sum.TotalPushes)
 	m["jobs_events_popped"] = float64(sum.TotalPops)
 	m["jobs_events_failed"] = float64(sum.TotalFailures)
+	m["jobs_events_permanently_failed"] = float64(sum.TotalPermanentFailures)
 	m["jobs_events_succeeded"] = float64(sum.TotalSuccesses)
 	m["jobs_events_completed"] = float64(sum.TotalCompletes)
 	if sum.TotalCompletes > 0 {
@@ -215,6 +218,7 @@ func (p FireworqPlugin) GraphDefinition() map[string]mp.Graphs {
 				{Name: "jobs_events_pushed", Label: "Pushed", Diff: true, Stacked: true},
 				{Name: "jobs_events_popped", Label: "Popped", Diff: true, Stacked: true},
 				{Name: "jobs_events_failed", Label: "Failed", Diff: true, Stacked: true},
+				{Name: "jobs_events_permanently_failed", Label: "Permanently Failed", Diff: true, Stacked: true},
 				{Name: "jobs_events_succeeded", Label: "Succeeded", Diff: true, Stacked: true},
 				{Name: "jobs_events_completed", Label: "Completed", Diff: true, Stacked: true},
 			},

--- a/lib/queuestat.go
+++ b/lib/queuestat.go
@@ -1,0 +1,88 @@
+package mpfireworq
+
+type QueueStat int64
+
+const (
+	Pushes            QueueStat = iota
+	Pops              QueueStat = iota
+	Successes         QueueStat = iota
+	Failures          QueueStat = iota
+	PermanentFailures QueueStat = iota
+	Completes         QueueStat = iota
+)
+
+func (s QueueStat) String() string {
+	switch s {
+	case Pushes:
+		return "pushes"
+	case Pops:
+		return "pops"
+	case Successes:
+		return "successes"
+	case Failures:
+		return "failures"
+	case PermanentFailures:
+		return "permanent_failures"
+	case Completes:
+		return "completed"
+	}
+	return "unknown"
+}
+
+func (s QueueStat) MetricName() string {
+	return "queue." + s.String()
+}
+
+func (s QueueStat) Metric(f *FireworqStats) int64 {
+	switch s {
+	case Pushes:
+		return f.TotalPushes
+	case Pops:
+		return f.TotalPops
+	case Successes:
+		return f.TotalSuccesses
+	case Failures:
+		return f.TotalFailures
+	case PermanentFailures:
+		return f.TotalPermanentFailures
+	case Completes:
+		return f.TotalCompletes
+	}
+	return 0
+}
+
+func (s QueueStat) Label() string {
+	switch s {
+	case Pushes:
+		return "Pushed Jobs"
+	case Pops:
+		return "Popped Jobs"
+	case Successes:
+		return "Succeeded Jobs"
+	case Failures:
+		return "Failed Jobs"
+	case PermanentFailures:
+		return "Permanently Failed Jobs"
+	case Completes:
+		return "Completed Jobs"
+	}
+	return "Unknown Stat"
+}
+
+func NewQueueStat(s string) QueueStat {
+    switch s {
+        case "pushes":
+			return Pushes
+		case "pops":
+			return Pops
+		case "successes":
+			return Successes
+		case "failures":
+			return Failures
+		case "permanent_failures":
+			return PermanentFailures
+		case "completes":
+			return Completes
+	}
+	panic("Unknown queue stat string: " + s)
+}


### PR DESCRIPTION
## `jobs_events_permanently_failed`
- A sum of permanently failed jobs of all queues.
  - Useful for external monitoring.

## `queue.(pushes|pops|successes|failure|permanent_failure|completes).*`
- Opt-in metrics per queue.
  - Useful for drill down.
- The default is nothing.
- We can configure by a command line argument like `-queue-stats="pushes,failure"` .